### PR TITLE
Change stock app service restart to always

### DIFF
--- a/stock_app.service
+++ b/stock_app.service
@@ -7,7 +7,8 @@ Conflicts=getty@tty1.service
 Type=simple
 User=kafkabridge
 ExecStart={{ venv_home }}/bin/python3 {{ venv_home }}/stock_app.py --serve-in-foreground
-Restart=on-abort
+Restart=always
+RestartSec=15
 StandardInput=tty-force
 
 [Install]


### PR DESCRIPTION
The service will always restart, with a 15 second delay between retries.